### PR TITLE
Standardize Data Types for Extracted Files

### DIFF
--- a/src/extract_archive.py
+++ b/src/extract_archive.py
@@ -81,6 +81,7 @@ def extract_archive(
                 output_path,
                 display_name=file.name,
                 original_path=original_path,
+                data_type=f"worker:openrelik:extraction:archive_extract:file",
                 source_file_id=input_file.get("uuid"),
             )
             os.rename(file.absolute(), output_file.path)

--- a/src/image_export_artifact.py
+++ b/src/image_export_artifact.py
@@ -121,7 +121,7 @@ def artifact_extract(
                 output_path,
                 display_name=file.name,
                 original_path=original_path,
-                data_type=f"openrelik:extraction:artifact:{artifact_name}",
+                data_type=f"worker:openrelik:extraction:artifact_extract:artifact:{artifact_name}",
             )
             os.rename(file.absolute(), output_file.path)
             output_files.append(output_file.to_dict())

--- a/src/image_export_file.py
+++ b/src/image_export_file.py
@@ -101,7 +101,7 @@ def file_extract(
                 output_path,
                 display_name=file.name,
                 original_path=original_path,
-                data_type=f"openrelik:extraction:file",
+                data_type=f"worker:openrelik:extraction:file_extract:file",
             )
             os.rename(file.absolute(), output_file.path)
             output_files.append(output_file.to_dict())


### PR DESCRIPTION
### Summary:
This change standardizes the `data_type` assigned to files extracted from archives, artifacts, and images by prepending "worker:" and using a consistent format.

### Technical Details:
* **Consistent `data_type` Format:**  The `data_type` values for extracted files across `extract_archive.py`, `image_export_artifact.py`, and `image_export_file.py` have been updated to include the prefix "worker:" and follow a more descriptive and consistent structure.  This improved consistency makes it easier to filter and query files based on their origin and extraction method.
* **`extract_archive.py` Update:** The `data_type` for files extracted from archives is changed from `openrelik:extraction:archive_extract:file` to `worker:openrelik:extraction:archive_extract:file`.
* **`image_export_artifact.py` Update:** The `data_type` for artifacts extracted from images is changed from `openrelik:extraction:artifact:{artifact_name}` to `worker:openrelik:extraction:artifact_extract:artifact:{artifact_name}`.
* **`image_export_file.py` Update:** The `data_type` for files extracted from images is changed from `openrelik:extraction:file` to `worker:openrelik:extraction:file_extract:file`.
* **Improved Data Management:** This standardization will improve data management and analysis by providing a clear and consistent way to categorize extracted files based on their source and extraction process. This will facilitate querying and filtering operations, simplifying data analysis workflows.

