### PR TITLE
Bugfix: Rename task function

### DIFF
--- a/src/extract_archive.py
+++ b/src/extract_archive.py
@@ -32,7 +32,7 @@ TASK_METADATA = {
 
 
 @celery.task(bind=True, name=TASK_NAME, metadata=TASK_METADATA)
-def extract_archive(
+def extract_archive_task(
     self,
     pipe_result: str = None,
     input_files: list = None,


### PR DESCRIPTION
Bugfix: The task function "extract_archive" is the same as the imported "extract_archive" from the worker-common lib. This confuses Celery who tries to execute the task multiple times and then fail.

Renaming the task function fixes the problem.