### PR TITLE
Add file filtering to archive extraction task

### DIFF
--- a/src/extract_archive.py
+++ b/src/extract_archive.py
@@ -28,6 +28,16 @@ TASK_NAME = "openrelik-worker-extraction.tasks.extract_archive"
 TASK_METADATA = {
     "display_name": "Extract Archives",
     "description": "Extract different types of archives",
+    "task_config": [
+        {
+            "name": "file_filter",
+            "label": "Select files (glob patterns) to extract",
+            "description": "A comma separated list of filenames to extract. Glob patterns are supported. Example: *.txt, *.evtx",
+            "type": "text",
+            "required": True,
+        },
+    ],
+
 }
 
 
@@ -54,14 +64,18 @@ def extract_archive_task(
     """
     input_files = get_input_files(pipe_result, input_files or [])
     output_files = []
+    file_filters = task_config.get("file_filter") or []
+    if file_filters:
+        file_filters = file_filters.split(",")
+
     for input_file in input_files:
         log_file = create_output_file(
             output_path,
-            display_name=f"archive_extract_{input_file.get("display_name")}",
+            display_name=f"extract_archives_{input_file.get("display_name")}.log",
         )
 
         (command_string, export_directory) = extract_archive(
-            input_file, output_path, log_file.path
+            input_file, output_path, log_file.path, file_filters
         )
 
         if os.path.isfile(log_file.path):

--- a/src/extract_archive.py
+++ b/src/extract_archive.py
@@ -32,7 +32,7 @@ TASK_METADATA = {
 
 
 @celery.task(bind=True, name=TASK_NAME, metadata=TASK_METADATA)
-def extract_archive(
+def extract_archive_task(
     self,
     pipe_result: str = None,
     input_files: list = None,


### PR DESCRIPTION
### Summary:
Introduced file filtering to the archive extraction task using glob patterns.

### Technical Details:
*   **Task Configuration:** Added a `file_filter` configuration option to the `extract_archive` task. This option accepts a comma-separated list of glob patterns, allowing users to specify which files to extract from the archive. The configuration is defined in the `TASK_METADATA` dictionary.
*   **Filtering Logic:** The `extract_archive_task` function now retrieves the `file_filter` from the task configuration. If filters are present, they are split into a list.
*   **Invocation Change:** The `extract_archive` function invocation now passes the file filters to the extraction function.
*   **Log file name change**: The log file name now starts with extract_archives, for better sorting and readability.