### PR TITLE
Add multi artifact meta data support through artifact mapping.

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,7 +20,7 @@ from openrelik_worker_common.debug_utils import start_debugger
 if os.getenv("OPENRELIK_PYDEBUG") == "1":
     start_debugger()
 
-REDIS_URL = os.getenv("REDIS_URL")
+REDIS_URL = os.getenv("REDIS_URL") or "redis://localhost:6379/0"
 celery = Celery(
     broker=REDIS_URL,
     backend=REDIS_URL,


### PR DESCRIPTION
image_export.py supports mapping extracted artifacts to to the artifact type through the `--enable_artifacts_map` switch.

This PR
* adds support for the `--enable_artifacts_map` switch
* parses the output map
* finds the correct artifact type per file with the `get_artifact_types` method
* handles many-to-one mappings of files that could have multiple artifact types
* assigns the correct artifact type to the output_file structure
* creates multiple seperate files if multiple artifact types match the same file
